### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ env_logger = "0.10.0"
 fallible-iterator = "0.2.0"
 log = "0.4.20"
 rand = "0.8.5"
-rusqlite = "0.29.0"
+rusqlite = { version = "0.29.0", features = ["bundled"] }
 rusqlite_migration = "1.0.2"
 rustls-pemfile = "1.0.3"
 serde = { version = "1.0.188", features = ["derive"] }


### PR DESCRIPTION
Add "bundled" to `resqlite` dependency. Resolves `LINK : fatal error LNK1181: cannot open input file 'sqlite3.lib'` error, as per [Notes on building rusqlite and libsqlite3-sys](https://github.com/rusqlite/rusqlite#user-content-notes-on-building-rusqlite-and-libsqlite3-sys)